### PR TITLE
Maintain order of interactions

### DIFF
--- a/assets/js/analyzer.js
+++ b/assets/js/analyzer.js
@@ -1,4 +1,5 @@
 var analyzers = {}, analyzerData = {};
+var currentAnalyzerRequest;
 
 if(modeEnabled('analyzation')) {
     $(document).ready(function () {
@@ -129,11 +130,18 @@ function analyze() {
     sendEvent('analyzer', 'analyze', analyzerMode, $('#morphAnalyzerInput').val().length);
 
     $('#morphAnalyzerOutput').addClass('blurred');
-    $.jsonp({
+
+    if(currentAnalyzerRequest) {
+        currentAnalyzerRequest.abort();
+    }
+    currentAnalyzerRequest = $.jsonp({
         url: config.APY_URL + '/analyze',
         pageCache: true,
         beforeSend: ajaxSend,
-        complete: ajaxComplete,
+        complete: function() {
+            ajaxComplete();
+            currentAnalyzerRequest = undefined;
+        },
         data: {
             'lang': analyzerMode,
             'q': $('#morphAnalyzerInput').val()

--- a/assets/js/generator.js
+++ b/assets/js/generator.js
@@ -1,4 +1,5 @@
 var generators = {}, generatorData = {};
+var currentGeneratorRequest;
 
 if(modeEnabled('generation')) {
     $(document).ready(function () {
@@ -129,10 +130,17 @@ function generate() {
     sendEvent('generator', 'generate', generatorMode, $('#morphGeneratorInput').val().length);
 
     $('#morphGenOutput').addClass('blurred');
-    $.jsonp({
+
+    if(currentGeneratorRequest) {
+        currentGeneratorRequest.abort();
+    }
+    currentGeneratorRequest = $.jsonp({
         url: config.APY_URL + '/generate',
         beforeSend: ajaxSend,
-        complete: ajaxComplete,
+        complete: function() {
+            ajaxComplete();
+            currentGeneratorRequest = undefined;
+        },
         data: {
             'lang': generatorMode,
             'q': $('#morphGeneratorInput').val()

--- a/assets/js/sandbox.js
+++ b/assets/js/sandbox.js
@@ -1,3 +1,5 @@
+var currentSandboxRequest;
+
 if(config.ENABLED_MODES === undefined || config.ENABLED_MODES.indexOf('sandbox') !== -1) {
     $(document).ready(function () {
         $('#request').click(function () {
@@ -22,7 +24,10 @@ if(config.ENABLED_MODES === undefined || config.ENABLED_MODES.indexOf('sandbox')
 function request() {
     $('#sandboxOutput').addClass('blurred');
     var start_time = new Date().getTime();
-    $.jsonp({
+    if(currentSandboxRequest) {
+        currentSandboxRequest.abort();
+    }
+    currentSandboxRequest = $.jsonp({
         url: config.APY_URL + $('#sandboxInput').val(),
         beforeSend: ajaxSend,
         success: function (data) {
@@ -34,6 +39,7 @@ function request() {
         complete: function () {
             ajaxComplete();
             $('#time').text((new Date().getTime() - start_time) + ' ms');
+            currentSandboxRequest = undefined;
         }
     });
 }

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -3,6 +3,7 @@ var srcLangs = [], dstLangs = [];
 var curSrcLang, curDstLang;
 var recentSrcLangs = [], recentDstLangs = [];
 var droppedFile;
+var textTranslateRequest;
 
 if(modeEnabled('translation')) {
     $(document).ready(function () {
@@ -409,10 +410,16 @@ function translateText() {
     if($('div#translateText').is(":visible")) {
         if(pairs[curSrcLang] && pairs[curSrcLang].indexOf(curDstLang) !== -1) {
             sendEvent('translator', 'translate', curSrcLang + '-' + curDstLang, $('#originalText').val().length);
-            $.jsonp({
+            if(textTranslateRequest) {
+                textTranslateRequest.abort();
+            }
+            textTranslateRequest = $.jsonp({
                 url: config.APY_URL + '/translate',
                 beforeSend: ajaxSend,
-                complete: ajaxComplete,
+                complete: function() {
+                    ajaxComplete();
+                    textTranslateRequest = undefined;
+                },
                 data: {
                     'langpair': curSrcLang + '|' + curDstLang,
                     'q': $('#originalText').val()
@@ -526,10 +533,16 @@ function translateDoc() {
 }
 
 function detectLanguage() {
-    $.jsonp({
+    if(textTranslateRequest) {
+        textTranslateRequest.abort();
+    }
+    textTranslateRequest = $.jsonp({
         url: config.APY_URL + '/identifyLang',
         beforeSend: ajaxSend,
-        complete: ajaxComplete,
+        complete: function() {
+            ajaxComplete();
+            textTranslateRequest = undefined;
+        },
         data: {
             'q': $('#originalText').val()
         },


### PR DESCRIPTION
This code will prevent two translation requests from happening at the same time.

from task comment I made:
There are two ways I can think of handling this. One is that we should abort any request irrespective of what it is doing when a new request is asked for, this is a simple method. Another is much more complicated. We maintain context of which side (src or dst) changed. Then we allow only one request per side at a time. As simple as this may sound the code becomes pretty complicated. What do you think? I am submitting the simpler approach. Not sure if it has bugs, but as far as I have tested it doesn't seem to have any weird bugs and since I have a 10kBps connection the requests are slow and it's much easier to test :smile: 