### PR TITLE
Changed GET to POST in translateText() function

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -581,28 +581,52 @@ function translateText() {
             }
             request.q = $('#originalText').val(); // eslint-disable-line id-length
             request.markUnknown = $('#markUnknown').prop('checked') ? 'yes' : 'no';
-            textTranslateRequest = $.ajax({
-                url: config.APY_URL + endpoint,
-                beforeSend: ajaxSend,
-                complete: function () {
-                    ajaxComplete();
-                    textTranslateRequest = undefined;
-                },
-                data: request,
-                type: 'POST',
-                contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
-                dataType: 'json',
-                success: function (data) {
-                    if(data.responseStatus === HTTP_OK_CODE) {
-                        $('#translatedText').val(data.responseData.translatedText);
-                        $('#translatedText').removeClass('notAvailable text-danger');
-                    }
-                    else {
-                        translationNotAvailable();
-                    }
-                },
-                error: translationNotAvailable
-            });
+
+            if(request.q.length > 1950){
+                textTranslateRequest = $.ajax({
+                    url: config.APY_URL + endpoint,
+                    beforeSend: ajaxSend,
+                    complete: function () {
+                        ajaxComplete();
+                        textTranslateRequest = undefined;
+                    },
+                    data: request,
+                    type: 'POST',
+                    contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
+                    dataType: 'json',
+                    success: function (data) {
+                        if(data.responseStatus === HTTP_OK_CODE) {
+                            $('#translatedText').val(data.responseData.translatedText);
+                            $('#translatedText').removeClass('notAvailable text-danger');
+                        }
+                        else {
+                            translationNotAvailable();
+                        }
+                    },
+                    error: translationNotAvailable
+                });
+            }
+            else{
+                textTranslateRequest = $.jsonp({
+                    url: config.APY_URL + endpoint,
+                    beforeSend: ajaxSend,
+                    complete: function () {
+                        ajaxComplete();
+                        textTranslateRequest = undefined;
+                    },
+                    data: request,
+                    success: function (data) {
+                        if(data.responseStatus === HTTP_OK_CODE) {
+                            $('#translatedText').val(data.responseData.translatedText);
+                            $('#translatedText').removeClass('notAvailable text-danger');
+                        }
+                        else {
+                            translationNotAvailable();
+                        }
+                    },
+                    error: translationNotAvailable
+                });
+            }
         }
         else {
             translationNotAvailable();

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -581,8 +581,8 @@ function translateText() {
             }
             request.q = $('#originalText').val(); // eslint-disable-line id-length
             request.markUnknown = $('#markUnknown').prop('checked') ? 'yes' : 'no';
-
-            if(request.q.length > 1950){
+            var thresholdLength = 1950;
+            if(request.q.length > thresholdLength){
                 textTranslateRequest = $.ajax({
                     url: config.APY_URL + endpoint,
                     beforeSend: ajaxSend,
@@ -606,7 +606,7 @@ function translateText() {
                     error: translationNotAvailable
                 });
             }
-            else{
+            else {
                 textTranslateRequest = $.jsonp({
                     url: config.APY_URL + endpoint,
                     beforeSend: ajaxSend,

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -581,7 +581,7 @@ function translateText() {
             }
             request.q = $('#originalText').val(); // eslint-disable-line id-length
             request.markUnknown = $('#markUnknown').prop('checked') ? 'yes' : 'no';
-            textTranslateRequest = $.jsonp({
+            textTranslateRequest = $.ajax({
                 url: config.APY_URL + endpoint,
                 beforeSend: ajaxSend,
                 complete: function () {
@@ -589,6 +589,9 @@ function translateText() {
                     textTranslateRequest = undefined;
                 },
                 data: request,
+                type: 'POST',
+                contentType: 'application/x-www-form-urlencoded; charset=UTF-8',
+                dataType: 'json',
                 success: function (data) {
                     if(data.responseStatus === HTTP_OK_CODE) {
                         $('#translatedText').val(data.responseData.translatedText);


### PR DESCRIPTION
Added this functionality currently only in translateText() function. This now ensures that the user can supply large texts in input text box and he wont get 414 error.
Will add this across generator, morphological analysis and analyser mode once I get comfortable with their functioning.