### PR TITLE
TypeError fixed in analyse and generate modes

### DIFF
--- a/assets/js/analyzer.js
+++ b/assets/js/analyzer.js
@@ -143,6 +143,10 @@ function populateSecondaryAnalyzerList() {
 }
 
 function analyze() {
+    if($('#primaryAnalyzerMode').val() == null) {
+        return;
+    }
+
     var analyzerMode = analyzers[$('#primaryAnalyzerMode').val()].length > 1
         ? $('#secondaryAnalyzerMode').val()
         : analyzers[$('#primaryAnalyzerMode').val()][0];

--- a/assets/js/analyzer.js
+++ b/assets/js/analyzer.js
@@ -143,7 +143,7 @@ function populateSecondaryAnalyzerList() {
 }
 
 function analyze() {
-    if($('#primaryAnalyzerMode').val() == null) {
+    if($('#primaryAnalyzerMode').val() === null) {
         return;
     }
 

--- a/assets/js/generator.js
+++ b/assets/js/generator.js
@@ -143,6 +143,10 @@ function populateSecondaryGeneratorList() {
 }
 
 function generate() {
+    if($('#primaryGeneratorMode').val() == null) {
+        return;
+    }
+
     var generatorMode = generators[$('#primaryGeneratorMode').val()].length > 1
         ? $('#secondaryGeneratorMode').val()
         : generators[$('#primaryGeneratorMode').val()][0];

--- a/assets/js/generator.js
+++ b/assets/js/generator.js
@@ -143,7 +143,7 @@ function populateSecondaryGeneratorList() {
 }
 
 function generate() {
-    if($('#primaryGeneratorMode').val() == null) {
+    if($('#primaryGeneratorMode').val() === null) {
         return;
     }
 


### PR DESCRIPTION
This patch fixes the type error `undefined` that is displayed in the console when the user clicks on `Analyse` or `Generate` without selecting an item from the dropdown. This PR aims to solve issue #122 . 
Following are the screenshots:

**Before:** 
![screen shot 2017-03-22 at 4 23 36 pm](https://cloud.githubusercontent.com/assets/8894636/24202173/5582797e-0f38-11e7-9c68-cd3f3d1dd3d8.png)


**After:**
![screen shot 2017-03-22 at 7 45 24 pm](https://cloud.githubusercontent.com/assets/8894636/24202120/2ea0eeb2-0f38-11e7-8e62-837b92f9b229.png)

The similar holds for Generate mode too.
