### PR TITLE
Removes the 400-Bad request error when detect language is clicked

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -736,6 +736,10 @@ function downloadBrowserWarn() {
     }
 }
 function detectLanguage() {
+    if($('#originalText').val().length === 0) {
+        return;
+    }
+
     if(textTranslateRequest) {
         textTranslateRequest.abort();
     }

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -736,7 +736,8 @@ function downloadBrowserWarn() {
     }
 }
 function detectLanguage() {
-    if($('#originalText').val().length === 0) {
+    var originalText = $('#originalText').val();
+    if(originalText.length === 0) {
         return;
     }
 
@@ -752,7 +753,7 @@ function detectLanguage() {
             textTranslateRequest = undefined;
         },
         data: {
-            'q': $('#originalText').val()
+            'q': originalText
         },
         success: function (data) {
             var possibleLanguages = [];


### PR DESCRIPTION
This patch first checks whether the data from `#originalText` is not empty. It lets the user make a `Detect Language` request only when the data is non-empty thereby, removing the `400-Bad Request Error.` This PR aims to solve the issue #124 . Following are the screenshots:

**Before**
![screen shot 2017-03-23 at 9 05 56 am](https://cloud.githubusercontent.com/assets/8894636/24231263/9989f130-0fa9-11e7-981f-1db3aa42f312.png)

**After**
![screen shot 2017-03-23 at 9 06 27 am](https://cloud.githubusercontent.com/assets/8894636/24231269/a23a7228-0fa9-11e7-8545-5610c39b6870.png)

