### PR TITLE
Fixes the issue of dropdown button being overlapped

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -249,6 +249,7 @@ html[dir=rtl] #srcLanguages {
 
 #srcLangSelectors {
     z-index: 100;
+    width: 90%;
 }
 
 @media(min-width: 768px) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -249,7 +249,7 @@ html[dir=rtl] #srcLanguages {
 
 #srcLangSelectors {
     z-index: 100;
-    width: 90%;
+    width: calc(100% - 50px);
 }
 
 @media(min-width: 768px) {

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -249,7 +249,7 @@ html[dir=rtl] #srcLanguages {
 
 #srcLangSelectors {
     z-index: 100;
-    width: calc(100% - 50px);
+    width: calc(100% - 34px);
 }
 
 @media(min-width: 768px) {


### PR DESCRIPTION
Fixes issue #65 .
The fix ensures that there is no overlap between `swapButton` and the `srcLangSelectors` divs in any case.