### PR TITLE
Fix container animation issue - issue 149

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -108,10 +108,10 @@ $(document).ready(function () {
         var mode = $(this).data('mode');
         $('.nav li').removeClass('active');
         $(this).parent('li').addClass('active');
-        $('.modeContainer:not(#' + mode + 'Container)').hide({
+        $('.modeContainer:not(#' + mode + 'Container)').stop().hide({
             queue: false
         });
-        $('#' + mode + 'Container').show({
+        $('#' + mode + 'Container').stop().show({
             queue: false
         });
         synchronizeTextareaHeights();


### PR DESCRIPTION
Attempt to fix #149 . I add a `stop()` method to the `hide()` and `show()` methods on clicking a container nav option. This ensures that when a nav `mode` is clicked, all animations applied on the navbar modes stop and continue afresh. According to me, currently, as the animations are not queued up( as `queue: false` ), clicking on another `mode` whilst a transitional animation is going on kind of messes up with the animations. All the records of animations get vanished thereby resulting in a blank screen.