### PR TITLE
Dropdown Alignment for locale names - Fix #19, #127

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -45,6 +45,12 @@ h2 {
     margin-top: 7px;
 }
 
+#localeDropdown {
+    width: 120px;
+    height: 300px;
+    overflow-y: scroll;
+}
+
 .nav-pills { /* sass-lint:disable-line class-name-format */
     cursor: pointer;
 }

--- a/assets/js/localization.js
+++ b/assets/js/localization.js
@@ -228,15 +228,15 @@ function getLocales() {
             );
 
             $('#localeDropdown').append(
-                $('<li></li>')
-                    .append(
-                        $('<a>', { href: 'index.' + this[0] + '.html' })
-                            .val(this[0])
-                            .text(this[1])
-                            .prop('dir', rtlLanguages.indexOf(this[0]) !== -1 ? 'rtl' : 'ltr')
-                            .css('padding-left', rtlLanguages.indexOf(this[0]) !== -1 ? '115px' : '5px')
-                            .css('padding-right', rtlLanguages.indexOf(this[0]) !== -1 ? '5px' : '115px')
-                    )
+                $('<li></li>').append(
+                    $('<a>', {
+                        href: 'index.' + this[0] + '.html' 
+                    })
+                        .text(this[1])
+                        .prop('dir', rtlLanguages.indexOf(this[0]) !== -1 ? 'rtl' : 'ltr')
+                        .css('padding-left', rtlLanguages.indexOf(this[0]) !== -1 ? '115px' : '5px')
+                        .css('padding-right', rtlLanguages.indexOf(this[0]) !== -1 ? '5px' : '115px')
+                    );
             );
         });
     }

--- a/assets/js/localization.js
+++ b/assets/js/localization.js
@@ -76,6 +76,12 @@ $(document).ready(function () {
             console.warn('No config.LOCALES');
         }
         $('.localeSelect').val(locale);
+        if(languages[iso639Codes[locale]]) {
+            $('#localeName').text(languages[iso639Codes[locale]]);
+        }
+        else {
+            $('#localeName').text(languages[locale]);
+        }
         localizeEverything(localizedHTML);
         persistChoices('localization');
     });
@@ -212,12 +218,25 @@ function getLocales() {
             return a[1].toLowerCase().localeCompare(b[1].toLowerCase());
         });
         $('.localeSelect').empty();
+        $('#localeNames').empty();
         $.each(localePairs, function () {
             $('.localeSelect').append(
                 $('<option></option>')
                     .val(this[0])
                     .text(this[1])
                     .prop('dir', rtlLanguages.indexOf(this[0]) !== -1 ? 'rtl' : 'ltr')
+            );
+
+            $('#localeDropdown').append(
+                $('<li></li>')
+                    .append(
+                        $('<a>', { href: 'index.' + this[0] + '.html' })
+                            .val(this[0])
+                            .text(this[1])
+                            .prop('dir', rtlLanguages.indexOf(this[0]) !== -1 ? 'rtl' : 'ltr')
+                            .css('padding-left', rtlLanguages.indexOf(this[0]) !== -1 ? '115px' : '5px')
+                            .css('padding-right', rtlLanguages.indexOf(this[0]) !== -1 ? '5px' : '115px')
+                    )
             );
         });
     }

--- a/index.html.in
+++ b/index.html.in
@@ -90,9 +90,11 @@
                       <p data-text="tagline" class="tagline"></p>
                   </div>
                   <div style="width: 35%" class="pull-right hidden-xs">
-                      <!-- <i class="icon-globe localeGlobe pull-right"></i> -->
                       <i class="fa fa-globe fa-2x fa-inverse pull-right localeGlobe" style="padding: 5px 5px 0px 0px"></i>
-                      <select class="localeSelect pull-right"><option> </option></select>
+                      <div class="dropdown pull-right">
+                          <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown"><span id="localeName"></span>&nbsp;&nbsp;<span class="caret"></span></button>
+                          <ul class="dropdown-menu" id="localeDropdown"></ul>
+                      </div> 
                   </div>
                   <ul class="nav navbar-nav navbar-right collapse navbar-collapse">
                     <li><a href="#translation" data-mode="translation" data-text="Translation" class="hide">Translation</a></li>

--- a/index.html.in
+++ b/index.html.in
@@ -94,7 +94,7 @@
                       <div class="dropdown pull-right">
                           <button class="btn btn-primary dropdown-toggle" type="button" data-toggle="dropdown"><span id="localeName"></span>&nbsp;&nbsp;<span class="caret"></span></button>
                           <ul class="dropdown-menu" id="localeDropdown"></ul>
-                      </div> 
+                      </div>
                   </div>
                   <ul class="nav navbar-nav navbar-right collapse navbar-collapse">
                     <li><a href="#translation" data-mode="translation" data-text="Translation" class="hide">Translation</a></li>


### PR DESCRIPTION
This PR aims to fix #19 and #127 . I make use of a `bootstrap dropdown` to display the `locales`. This dropdown is visible only on larger (non-mobile devices) and it reverts to the current `select` feature for displaying the `locales` while on mobile devices. 

Currently, for 3 lanaguages, the `bootstrap button` does not display the name of the locale. For instance, `qaraqalpaksha`. I could not find this name (and 2 others) anywhere (neither in `languages` nor in `iso639Codes` and hence, am unable to populate this name currently ). How are the `select options` for these languages getting populated in the current functionality?