### PR TITLE
translateText() called only after detectLanguage() completes - fix issue #166

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -169,7 +169,7 @@ if(modeEnabled('translation')) {
         $('#detect').click(function () {
             $('.srcLang').removeClass('active');
             $(this).addClass('active');
-            $.when(detectLanguage()).done(function (x) {
+            $.when(detectLanguage()).done(function () {
                 translateText();
             });
         });

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -65,18 +65,16 @@ if(modeEnabled('translation')) {
             handleNewCurrentLang(curDstLang, recentDstLangs, 'dstLang');
         });
 
-        $('.srcLang').click(function () {
-            if(this.id !== 'detect') {
-                curSrcLang = $(this).attr('data-code');
-                $('.srcLang').removeClass('active');
-                $(this).addClass('active');
-                populateTranslationList();
-                refreshLangList(true);
-                muteLanguages();
-                localizeInterface();
-                translateText();
-                autoSelectDstLang();
-            }
+        $('.srcLang:not(#detect)').click(function () {
+            curSrcLang = $(this).attr('data-code');
+            $('.srcLang').removeClass('active');
+            $(this).addClass('active');
+            populateTranslationList();
+            refreshLangList(true);
+            muteLanguages();
+            localizeInterface();
+            translateText();
+            autoSelectDstLang();
         });
 
         $('.dstLang').click(function () {

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -169,7 +169,7 @@ if(modeEnabled('translation')) {
         $('#detect').click(function () {
             $('.srcLang').removeClass('active');
             $(this).addClass('active');
-            $.when(detectLanguage()).done(function () {
+            $.when(detectLanguage()).done(function (x) {
                 translateText();
             });
         });

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -66,18 +66,17 @@ if(modeEnabled('translation')) {
         });
 
         $('.srcLang').click(function () {
-            curSrcLang = $(this).attr('data-code');
-            $('.srcLang').removeClass('active');
-            $(this).addClass('active');
-            populateTranslationList();
-            refreshLangList(true);
-            muteLanguages();
-            localizeInterface();
             if(this.id !== 'detect') {
+                curSrcLang = $(this).attr('data-code');
+                $('.srcLang').removeClass('active');
+                $(this).addClass('active');
+                populateTranslationList();
+                refreshLangList(true);
+                muteLanguages();
+                localizeInterface();
                 translateText();
+                autoSelectDstLang();
             }
-
-            autoSelectDstLang();
         });
 
         $('.dstLang').click(function () {
@@ -169,9 +168,7 @@ if(modeEnabled('translation')) {
         $('#detect').click(function () {
             $('.srcLang').removeClass('active');
             $(this).addClass('active');
-            $.when(detectLanguage()).done(function () {
-                translateText();
-            });
+            $.when(detectLanguage()).done(translateText);
         });
 
         $('.swapLangBtn').click(function () {
@@ -209,9 +206,7 @@ if(modeEnabled('translation')) {
         $('#srcLangSelect').change(function () {
             var selectValue = $(this).val();
             if(selectValue === 'detect') {
-                $.when(detectLanguage()).done(function () {
-                    translateText();
-                });
+                $.when(detectLanguage()).done(translateText);
             }
             else {
                 handleNewCurrentLang(curSrcLang = $(this).val(), recentSrcLangs, 'srcLang', true);

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -73,8 +73,8 @@ if(modeEnabled('translation')) {
             refreshLangList(true);
             muteLanguages();
             localizeInterface();
-            translateText();
             autoSelectDstLang();
+            translateText();
         });
 
         $('.dstLang').click(function () {

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -753,7 +753,7 @@ function detectLanguage() {
         textTranslateRequest.abort();
     }
 
-    return textTranslateRequest = callApy({
+    textTranslateRequest = callApy({
         data: {
             'q': originalText
         },
@@ -764,6 +764,8 @@ function detectLanguage() {
             textTranslateRequest = undefined;
         }
     }, '/identifyLang');
+
+    return textTranslateRequest;
 }
 
 function detectLanguageSuccessResponse(data) {

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -743,6 +743,7 @@ function downloadBrowserWarn() {
         }
     }
 }
+
 function detectLanguage() {
     var originalText = $('#originalText').val();
     if(originalText.length === 0) {
@@ -757,8 +758,8 @@ function detectLanguage() {
         data: {
             'q': originalText
         },
-        success: detectLanguageSuccessResponse,
-        error: detectLanguageErrorResponse,
+        success: handleDetectLanguageSuccessResponse,
+        error: handleDetectLanguageErrorResponse,
         complete: function () {
             ajaxComplete();
             textTranslateRequest = undefined;
@@ -766,41 +767,41 @@ function detectLanguage() {
     }, '/identifyLang');
 
     return textTranslateRequest;
-}
 
-function detectLanguageSuccessResponse(data) {
-    var possibleLanguages = [];
-    for(var lang in data) {
-        possibleLanguages.push([lang.indexOf('-') !== -1 ? lang.split('-')[0] : lang, data[lang]]);
-    }
-    possibleLanguages.sort(function (a, b) {
-        return b[1] - a[1];
-    });
-
-    var oldSrcLangs = recentSrcLangs;
-    recentSrcLangs = [];
-    for(var i = 0; i < possibleLanguages.length; i++) {
-        if(recentSrcLangs.length < TRANSLATION_LIST_BUTTONS && possibleLanguages[i][0] in pairs) {
-            recentSrcLangs.push(possibleLanguages[i][0]);
+    function handleDetectLanguageSuccessResponse(data) {
+        var possibleLanguages = [];
+        for(var lang in data) {
+            possibleLanguages.push([lang.indexOf('-') !== -1 ? lang.split('-')[0] : lang, data[lang]]);
         }
+        possibleLanguages.sort(function (a, b) {
+            return b[1] - a[1];
+        });
+
+        var oldSrcLangs = recentSrcLangs;
+        recentSrcLangs = [];
+        for(var i = 0; i < possibleLanguages.length; i++) {
+            if(recentSrcLangs.length < TRANSLATION_LIST_BUTTONS && possibleLanguages[i][0] in pairs) {
+                recentSrcLangs.push(possibleLanguages[i][0]);
+            }
+        }
+        recentSrcLangs = recentSrcLangs.concat(oldSrcLangs);
+        if(recentSrcLangs.length > TRANSLATION_LIST_BUTTONS) {
+            recentSrcLangs = recentSrcLangs.slice(0, TRANSLATION_LIST_BUTTONS);
+        }
+
+        curSrcLang = recentSrcLangs[0];
+        $('#srcLangSelect').val(curSrcLang);
+        muteLanguages();
+
+        $('#detectedText').parent('.srcLang').attr('data-code', curSrcLang);
+        refreshLangList();
+        $('#detectedText').show();
+        $('#detectText').hide();
     }
-    recentSrcLangs = recentSrcLangs.concat(oldSrcLangs);
-    if(recentSrcLangs.length > TRANSLATION_LIST_BUTTONS) {
-        recentSrcLangs = recentSrcLangs.slice(0, TRANSLATION_LIST_BUTTONS);
+
+    function handleDetectLanguageErrorResponse() {
+        $('#srcLang1').click();
     }
-
-    curSrcLang = recentSrcLangs[0];
-    $('#srcLangSelect').val(curSrcLang);
-    muteLanguages();
-
-    $('#detectedText').parent('.srcLang').attr('data-code', curSrcLang);
-    refreshLangList();
-    $('#detectedText').show();
-    $('#detectText').hide();
-}
-
-function detectLanguageErrorResponse() {
-    $('#srcLang1').click();
 }
 
 function translationNotAvailable() {


### PR DESCRIPTION
This PR aims to solve #166 . `translateText` now defers until `detectLanguage` is called. Also, `detectLanguage` is wrapped around `callApy()` method.