### PR TITLE
Auto select of destination language for a source language on small screen - Fix #170

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -196,7 +196,6 @@ if(modeEnabled('translation')) {
 
             refreshLangList(true);
             muteLanguages();
-            autoSelectDstLang();
 
             if($('.active > #detectedText')) {
                 $('.srcLang').removeClass('active');

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -196,7 +196,8 @@ if(modeEnabled('translation')) {
 
             refreshLangList(true);
             muteLanguages();
-
+            autoSelectDstLang();
+            
             if($('.active > #detectedText')) {
                 $('.srcLang').removeClass('active');
                 $('#srcLang' + (recentSrcLangs.indexOf(curSrcLang) + 1)).addClass('active');
@@ -211,6 +212,7 @@ if(modeEnabled('translation')) {
             }
             else {
                 handleNewCurrentLang(curSrcLang = $(this).val(), recentSrcLangs, 'srcLang', true);
+                autoSelectDstLang();
             }
         });
 
@@ -834,7 +836,7 @@ function autoSelectDstLang() {
         if(!newDstLang) {
             newDstLang = pairs[curSrcLang][0];
         }
-
+        $('#dstLangSelect').val(newDstLang).change();
         if(recentDstLangs.indexOf(newDstLang) === -1) {
             handleNewCurrentLang(newDstLang, recentDstLangs, 'dstLang');
         }

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -836,7 +836,9 @@ function autoSelectDstLang() {
         if(!newDstLang) {
             newDstLang = pairs[curSrcLang][0];
         }
+
         $('#dstLangSelect').val(newDstLang).change();
+        
         if(recentDstLangs.indexOf(newDstLang) === -1) {
             handleNewCurrentLang(newDstLang, recentDstLangs, 'dstLang');
         }

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -197,7 +197,7 @@ if(modeEnabled('translation')) {
             refreshLangList(true);
             muteLanguages();
             autoSelectDstLang();
-            
+
             if($('.active > #detectedText')) {
                 $('.srcLang').removeClass('active');
                 $('#srcLang' + (recentSrcLangs.indexOf(curSrcLang) + 1)).addClass('active');
@@ -838,7 +838,7 @@ function autoSelectDstLang() {
         }
 
         $('#dstLangSelect').val(newDstLang).change();
-        
+
         if(recentDstLangs.indexOf(newDstLang) === -1) {
             handleNewCurrentLang(newDstLang, recentDstLangs, 'dstLang');
         }


### PR DESCRIPTION
Fixes #170 . This PR selects a destination language for a selected source language for the views (-xs). This patch also implements the behaviour discussed in this [comment](https://github.com/goavki/apertium-html-tools/issues/170#issuecomment-317164866). - L199. If this behaviour is incorrect, we could simply remove this line.