### PR TITLE
autoDstSelectLang() called inside detectLanguage() and updates URL - Fix #131

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -850,7 +850,6 @@ function autoSelectDstLang() {
             newDstLang = pairs[curSrcLang][0];
         }
 
-        $('#dstLangSelect').val(newDstLang).change();
         curDstLang = newDstLang;
 
         if(recentDstLangs.indexOf(newDstLang) === -1) {
@@ -864,6 +863,8 @@ function autoSelectDstLang() {
             localizeInterface();
             translateText();
         }
+
+        $('#dstLangSelect').val(newDstLang).change();
     }
 }
 

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -795,6 +795,7 @@ function detectLanguage() {
         }
 
         curSrcLang = recentSrcLangs[0];
+        autoSelectDstLang();
         $('#srcLangSelect').val(curSrcLang);
         muteLanguages();
 
@@ -850,12 +851,12 @@ function autoSelectDstLang() {
         }
 
         $('#dstLangSelect').val(newDstLang).change();
-
+        curDstLang = newDstLang;
+        
         if(recentDstLangs.indexOf(newDstLang) === -1) {
             handleNewCurrentLang(newDstLang, recentDstLangs, 'dstLang');
         }
         else {
-            curDstLang = newDstLang;
             $('.dstLang').removeClass('active');
             refreshLangList();
             $('.dstLang[data-code=' + curDstLang + ']').addClass('active');

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -852,7 +852,7 @@ function autoSelectDstLang() {
 
         $('#dstLangSelect').val(newDstLang).change();
         curDstLang = newDstLang;
-        
+
         if(recentDstLangs.indexOf(newDstLang) === -1) {
             handleNewCurrentLang(newDstLang, recentDstLangs, 'dstLang');
         }


### PR DESCRIPTION
Fixes #131 . `autoDstSelectLang()` must be called corresponding to the `cursSrcLang` in the success handler of `detectLanguage()` to obtain the corresponding destination language. Irrespective of whether the `newDstLang` is present in the `recentDstLangs`, the `curDstLang` must be updated with the `newDstLang`. 