### PR TITLE
apyRequestStartTime made null after every APy call - Fix #190

### DIFF
--- a/assets/js/util.js
+++ b/assets/js/util.js
@@ -65,7 +65,10 @@ function ajaxSend() {
 function ajaxComplete() {
     $('#loadingIndicator').hide();
     clearTimeout(apyRequestTimeout);
-    handleAPyRequestCompletion(Date.now() - apyRequestStartTime);
+    if(apyRequestStartTime) {
+        handleAPyRequestCompletion(Date.now() - apyRequestStartTime);
+        apyRequestStartTime = undefined;
+    }
 }
 
 $(document).ajaxSend(ajaxSend);


### PR DESCRIPTION
`handleAPyRequestCompletion()` called only if an AJAX request is invoked from within `callApy()` (As `apyRequestStartTime` is defined in this function). If any other AJAX request is made, as `aspRequestStartTime` would be undefined, the above check would not be made and thus, it will not show the installation Notification erroneously. Fix #190 .