### PR TITLE
Use translateBtn class commonly across interface for 'translate' button - Fix #192

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -89,7 +89,7 @@ if(modeEnabled('translation')) {
             translateText();
         });
 
-        $('button#translate').click(function () {
+        $('.translateBtn').click(function () {
             translate();
             persistChoices('translator', true);
         });


### PR DESCRIPTION
Fix #192 