### PR TITLE
Removes inline styling

### DIFF
--- a/.htmlhintrc.json
+++ b/.htmlhintrc.json
@@ -10,6 +10,7 @@
   "alt-require": true,
   "doctype-html5": true,
   "style-disabled": true,
+  "inline-style-disabled": true,
   "inline-script-disabled": true,
   "space-tab-mixed-disabled": "space",
   "id-class-ad-disabled": true,

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -103,6 +103,144 @@ html[dir='rtl'] .clearButton {
     padding-bottom: 10px;
 }
 
+.posRelative {
+    position: relative;
+}
+
+#apertiumLogo {
+    margin-bottom: -.25em;
+}
+
+#localeSelectDiv {
+    width: 35%;
+}
+
+#localeGlobeIcon {
+    padding: 5px 5px 0 0;
+}
+
+#srcLangSelect,
+#dstLangSelect {
+    display: inline-block !important; /* sass-lint:disable-line no-important */
+}
+
+#cancelTranslateWebpage {
+    display: none;
+}
+
+#translateDoc {
+    margin-top: 1em;
+}
+
+#fileDropBackdrop {
+    display: none;
+    z-index: 1000;
+}
+
+#modalWell {
+    left: 35%;
+    position: absolute;
+    text-align: center;
+    top: 35%;
+}
+
+.dropDocHeader {
+    font-weight: bold;
+}
+
+#fileDropMask {
+    opacity: 0;
+    z-index: 10000;
+}
+
+.noDisplay {
+    display: none;
+}
+
+#uploadProgress {
+    margin-bottom: 0;
+}
+
+#uploadContainer {
+    margin-top: 1em;
+    min-height: 50px;
+}
+
+#fileLoading {
+    left: 50%;
+    position: absolute;
+    top: 50%;
+}
+
+#fileUploadProgress {
+    width: 0%;
+}
+
+#morphAnalyzerOutput {
+    border-spacing: 0;
+}
+
+#localeGlobeIconXs {
+    padding: 5px 0 0 5px;
+}
+
+.display-inline { /* sass-lint:disable-line class-name-format */
+    display: inline-block !important; /* sass-lint:disable-line no-important */
+}
+
+#helpMessage {
+    margin-top: 10px;
+}
+
+#maintainer {
+    padding-bottom: 2em;
+}
+
+.nodecoration {
+    text-decoration: none;
+}
+
+#byteMarkImg {
+    margin-top: .5em;
+    width: 100%;
+}
+
+#sourceForgeImg {
+    margin-top: .25em;
+    width: 100%;
+}
+
+.pointerCursor {
+    cursor: pointer;
+}
+
+#gsocImg {
+    height: 2.5em;
+}
+
+#gciImg {
+    height: 2.5em;
+    padding-left: .5em;
+}
+
+.halfEmMargin {
+    margin: 0 .5em;
+}
+
+#apertiumImg {
+    height: 5em;
+    max-width: 100%;
+}
+
+.noborder {
+    border: 0;
+}
+
+#apertiumImgContainer {
+    margin-bottom: 1.5em;
+}
+
+
 /* Navbar */
 
 .apertiumBox {
@@ -137,7 +275,7 @@ html[dir='rtl'] .clearButton {
     top: .7em;
 }
 
-.apertiumSubLogo + .apertiumLogo {
+.apertiumSubLogo+.apertiumLogo {
     top: .5em;
     z-index: 1;
 }
@@ -195,6 +333,7 @@ html[dir='rtl'] .apertiumLogo {
         padding-right: 5px;
     }
 }
+
 
 /* Translation */
 
@@ -259,7 +398,7 @@ html[dir='rtl'] #srcLanguages {
 }
 
 #srcLangSelectors {
-   padding-left: 0;
+    padding-left: 0;
 }
 
 @media(min-width: 768px) {
@@ -267,11 +406,9 @@ html[dir='rtl'] #srcLanguages {
         position: absolute;
         top: 0;
     }
-
     html[dir='ltr'] .swapLangBtn {
         right: 15px;
     }
-
     html[dir='rtl'] .swapLangBtn {
         left: 15px;
     }
@@ -311,13 +448,16 @@ html[dir='rtl'] #srcLanguages {
     margin-right: 5px;
 }
 
+
 /* Analysis */
 
 .unit {
     margin-left: 30px;
 }
 
+
 /* No JS Banner */
+
 #noscript {
     position: fixed;
     right: 0;
@@ -331,9 +471,10 @@ html[dir='rtl'] #srcLanguages {
     margin-top: 4em;
 }
 
-body > .container {
+body>.container {
     margin-top: 4em;
 }
+
 
 /* Footer */
 
@@ -342,7 +483,9 @@ body {
     height: 100%; /* The html and body elements cannot have any padding or margin. */
 }
 
+
 /* Wrapper for page content to push down footer */
+
 #wrap {
     height: auto !important; /* sass-lint:disable-line no-important */
     margin: 0 auto -60px; /* Negative indent footer by it's height */
@@ -350,14 +493,16 @@ body {
 }
 
 #push {
-    height: 60px; /* Set the fixed height of the footer */
+    height: 60px;  /* Set the fixed height of the footer */
 }
 
 #footer {
     height: auto;
 }
 
+
 /* Lastly, apply responsive CSS fixes as necessary */
+
 @media(max-width: 767px) {
     #footer {
         margin-left: -20px;
@@ -383,9 +528,12 @@ body {
     top: 40px;
 }
 
-#version:hover, #version:active, #version:focus {
+#version:hover,
+#version:active,
+#version:focus {
     text-decoration: none;
 }
+
 
 /* RTL Stuff */
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -103,15 +103,11 @@ html[dir='rtl'] .clearButton {
     padding-bottom: 10px;
 }
 
-.posRelative {
-    position: relative;
-}
-
 #apertiumLogo {
     margin-bottom: -.25em;
 }
 
-#localeSelectDiv {
+#localeSelectContainer {
     width: 35%;
 }
 
@@ -122,14 +118,6 @@ html[dir='rtl'] .clearButton {
 #srcLangSelect,
 #dstLangSelect {
     display: inline-block !important; /* sass-lint:disable-line no-important */
-}
-
-#cancelTranslateWebpage {
-    display: none;
-}
-
-#translateDoc {
-    margin-top: 1em;
 }
 
 #fileDropBackdrop {
@@ -180,7 +168,7 @@ html[dir='rtl'] .clearButton {
     border-spacing: 0;
 }
 
-#localeGlobeIconXs {
+#localeGlobeIconXS {
     padding: 5px 0 0 5px;
 }
 
@@ -188,16 +176,12 @@ html[dir='rtl'] .clearButton {
     display: inline-block !important; /* sass-lint:disable-line no-important */
 }
 
-#helpMessage {
+#helpMessageXS {
     margin-top: 10px;
 }
 
 #maintainer {
     padding-bottom: 2em;
-}
-
-.nodecoration {
-    text-decoration: none;
 }
 
 #byteMarkImg {
@@ -210,7 +194,7 @@ html[dir='rtl'] .clearButton {
     width: 100%;
 }
 
-.pointerCursor {
+.helpMessage {
     cursor: pointer;
 }
 
@@ -227,19 +211,14 @@ html[dir='rtl'] .clearButton {
     margin: 0 .5em;
 }
 
-#apertiumImg {
-    height: 5em;
-    max-width: 100%;
-}
-
-.noborder {
-    border: 0;
-}
-
 #apertiumImgContainer {
     margin-bottom: 1.5em;
 }
 
+#apertiumImgContainer img{
+    height: 5em;
+    max-width: 100%;
+}
 
 /* Navbar */
 
@@ -449,13 +428,15 @@ html[dir='rtl'] #srcLanguages {
     margin-right: 5px;
 }
 
+#translateDoc {
+    margin-top: 1em;
+}
 
 /* Analysis */
 
 .unit {
     margin-left: 30px;
 }
-
 
 /* No JS Banner */
 
@@ -475,7 +456,6 @@ html[dir='rtl'] #srcLanguages {
 body > .container {
     margin-top: 4em;
 }
-
 
 /* Footer */
 
@@ -534,7 +514,6 @@ body {
 #version:focus {
     text-decoration: none;
 }
-
 
 /* RTL Stuff */
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -137,14 +137,14 @@ html[dir='rtl'] .clearButton {
     z-index: 1000;
 }
 
-#modalWell {
+#fileDropBackdrop .well {
     left: 35%;
     position: absolute;
     text-align: center;
     top: 35%;
 }
 
-.dropDocHeader {
+#fileDropBackdrop h1 {
     font-weight: bold;
 }
 
@@ -153,7 +153,7 @@ html[dir='rtl'] .clearButton {
     z-index: 10000;
 }
 
-.noDisplay {
+.hide {
     display: none;
 }
 
@@ -223,7 +223,7 @@ html[dir='rtl'] .clearButton {
     padding-left: .5em;
 }
 
-.halfEmMargin {
+.licenseCol {
     margin: 0 .5em;
 }
 
@@ -275,7 +275,7 @@ html[dir='rtl'] .clearButton {
     top: .7em;
 }
 
-.apertiumSubLogo+.apertiumLogo {
+.apertiumSubLogo + .apertiumLogo {
     top: .5em;
     z-index: 1;
 }
@@ -333,7 +333,6 @@ html[dir='rtl'] .apertiumLogo {
         padding-right: 5px;
     }
 }
-
 
 /* Translation */
 
@@ -406,9 +405,11 @@ html[dir='rtl'] #srcLanguages {
         position: absolute;
         top: 0;
     }
+
     html[dir='ltr'] .swapLangBtn {
         right: 15px;
     }
+
     html[dir='rtl'] .swapLangBtn {
         left: 15px;
     }
@@ -471,7 +472,7 @@ html[dir='rtl'] #srcLanguages {
     margin-top: 4em;
 }
 
-body>.container {
+body > .container {
     margin-top: 4em;
 }
 
@@ -493,7 +494,7 @@ body {
 }
 
 #push {
-    height: 60px;  /* Set the fixed height of the footer */
+    height: 60px; /* Set the fixed height of the footer */
 }
 
 #footer {

--- a/index.html.in
+++ b/index.html.in
@@ -74,7 +74,7 @@
 
         <div id="wrap">
           <nav class="navbar navbar-default" role="navigation">
-              <div class="container" style="position: relative">
+              <div class="container posRelative">
                   <div class="navbar-header">
                       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                           <span class="sr-only">Toggle navigation</span>
@@ -85,13 +85,13 @@
                       <div>
                           <img src="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7" alt="Apertium Box" class="apertiumBox">
                           <span class="apertiumSubLogo"></span>
-                          <span class="apertiumLogo" style="margin-bottom: -.25em">Apertium</span>
+                          <span class="apertiumLogo" id="apertiumLogo">Apertium</span>
                       </div>
                       <p data-text="tagline" class="tagline"></p>
                   </div>
-                  <div style="width: 35%" class="pull-right hidden-xs">
+                  <div id="localeSelectDiv" class="pull-right hidden-xs">
                       <!-- <i class="icon-globe localeGlobe pull-right"></i> -->
-                      <i class="fa fa-globe fa-2x fa-inverse pull-right localeGlobe" style="padding: 5px 5px 0px 0px"></i>
+                      <i class="fa fa-globe fa-2x fa-inverse pull-right localeGlobe" id="localeGlobeIcon"></i>
                       <select class="localeSelect pull-right"><option> </option></select>
                   </div>
                   <ul class="nav navbar-nav navbar-right collapse navbar-collapse">
@@ -113,11 +113,11 @@
                           <legend data-text="Translation_Help"></legend>
                           <div class="form-group visible-xs">
                               <div class="col-sm-12">
-                                  <select class="langSelect" id="srcLangSelect" style="display: inline-block !important">
+                                  <select class="langSelect" id="srcLangSelect">
                                       <option data-text="Detect_Language" value="detect">Detect language</option>
                                   </select>
                                   <button type="button" class="btn btn-default btn-xs swapLangBtn"><i class="fa fa-exchange"></i></button>
-                                  <select class="langSelect" id="dstLangSelect" style="display: inline-block !important">
+                                  <select class="langSelect" id="dstLangSelect">
                                       <option> </option>
                                   </select>
                                   <button type="button" class="btn btn-primary btn-xs pull-right translateBtn" data-text="Translate">Translate</button>
@@ -125,7 +125,7 @@
                           </div>
                           <div class="form-group hidden-xs">
                               <div class="col-sm-6">
-                                  <button type="button" class="btn btn-sm btn-default pull-left" id="cancelTranslateWebpage" style="display: none;">
+                                  <button type="button" class="btn btn-sm btn-default pull-left" id="cancelTranslateWebpage">
                                       <i class="fa fa-arrow-left"></i> <span data-text="Cancel">Cancel</span>
                                   </button>
                                   <div class="btn-group col-sm-11" id="srcLangSelectors">
@@ -190,7 +190,7 @@
                                       <textarea class="form-control" id="translatedText" rows="15" spellcheck="false" readonly></textarea>
                                   </div>
                                   <div class="col-sm-6">
-                                      <button id="translateDoc" class="btn btn-default" style="margin-top: 1em;">
+                                      <button id="translateDoc" class="btn btn-default">
                                           <i class="fa fa-file-text"></i> <span data-text="Translate_Document">Translate a document</span>
                                       </button>
                                       <button id="showTranslateWebpage" class="btn btn-default">
@@ -217,22 +217,22 @@
                                   </div>
                               </div>
 
-                              <div class="modal-backdrop" id="fileDropBackdrop" style="display: none; z-index: 1000;">
-                                <div class="well well-lg" style="text-align: center; position: absolute; top: 35%; left: 35%;">
-                                    <h1 style="font-weight: bold;" data-text="Drop_Document">Drop your document</h1>
+                              <div class="modal-backdrop" id="fileDropBackdrop">
+                                <div class="well well-lg" id="modalWell">
+                                    <h1 id="dropDocHeader" data-text="Drop_Document">Drop your document</h1>
                                 </div>
-                                <div class="modal-backdrop" id="fileDropMask" style="opacity: 0; z-index: 10000;"></div>
+                                <div class="modal-backdrop" id="fileDropMask"></div>
                               </div>
 
-                              <div id="docTranslation" style="display: none;">
+                              <div id="docTranslation" class="noDisplay">
                                   <div class="col-sm-6">
                                       <div class="well well-lg">
                                           <input type="file" id="fileInput" accept="text/plain,text/html,text/rtf,application/rtf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/x-latex,application/x-tex">
-                                          <div class="lead" id="fileName" style="display: none;"></div>
-                                          <div style="min-height: 50px; margin-top: 1em;">
-                                              <span id="uploadError" class="text-danger lead" style="display: none"></span>
-                                              <div class="progress progress-striped active" style="display: none; margin-bottom: 0px;">
-                                                  <div id="fileUploadProgress" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100" style="width: 0%"></div>
+                                          <div class="lead" id="fileName" class="noDisplay"></div>
+                                          <div id="uploadContainer">
+                                              <span id="uploadError" class="text-danger lead noDisplay"></span>
+                                              <div class="progress progress-striped active noDisplay" id="uploadProgress">
+                                                  <div id="fileUploadProgress" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
                                               </div>
                                           </div>
                                           <p><span data-text="Supported_Formats"></span></p>
@@ -242,16 +242,16 @@
                                       </div>
                                   </div>
                                   <div class="col-sm-6">
-                                      <div id="fileLoading" class="text-center" style="display: none; position: absolute; top: 50%; left: 50%;">
+                                      <div id="fileLoading" class="text-center noDisplay">
                                           <i class="fa fa-spinner fa-spin fa-4x"></i>
                                       </div>
                                       <h1>
-                                          <a id="fileDownload" href="#" class="text-center lead" style="display: none;">
+                                          <a id="fileDownload" href="#" class="text-center lead noDisplay">
                                               <i class="fa fa-download"></i>
                                               <span id="fileDownloadText"></span>
                                           </a>
                                       </h1>
-                                      <p style="display:none" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser might not handle downloads correctly. Either right-click and "Save As" that file-name or open this page in Firefox.</p>
+                                      <p class="noDisplay" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser might not handle downloads correctly. Either right-click and "Save As" that file-name or open this page in Firefox.</p>
                                   </div>
                               </div>
                               <div id="translateWebpage">
@@ -303,7 +303,7 @@
                       </fieldset>
                   </form>
 
-                  <table class="table table-hover outputContainer" id="morphAnalyzerOutput" style="border-spacing: 0px;"></table>
+                  <table class="table table-hover outputContainer" id="morphAnalyzerOutput"></table>
               </div>
               <div class="modeContainer" id="generationContainer">
                   <h2 class="visible-xs" data-text="Morphological_Generation">Morphological generation</h2>
@@ -368,7 +368,7 @@
               </div>
               <div class="visible-xs">
                   <select class="localeSelect pull-left"><option> </option></select>
-                  <i class="fa fa-globe fa-2x pull-left localeGlobe" style="padding: 5px 0px 0px 5px"></i>
+                  <i class="fa fa-globe fa-2x pull-left localeGlobe" id="localeGlobeIconXs"></i>
                   <!-- <i class="fa fa-globe localeGlobe pull-left"></i> -->
               </div>
           </div>
@@ -378,7 +378,7 @@
         <div id="footer">
             <div class="navbar-bottom hidden-xs">
                 <div class="container" id="footer-container">
-                    <ul class="nav nav-pills pull-left" style="display: inline-block;">
+                    <ul class="nav nav-pills pull-left display-inline">
                         <li><a data-toggle="modal" data-target="#aboutModal" data-keyboard="true"><i class="fa fa-question-circle"></i> <span data-text="About">About</span></a></li>
                         <li><a data-toggle="modal" data-target="#downloadModal" data-keyboard="true"><i class="fa fa-download"></i> <span data-text="Download">Download</span></a></li>
                         <li><a data-toggle="modal" data-target="#docModal" data-keyboard="true"><i class="fa fa-book"></i> <span data-text="Documentation">Documentation</span></a></li>
@@ -386,7 +386,7 @@
                     </ul>
                     <div class="pull-right well well-sm helpMessage">
                         <span data-text="Notice_Mistake">Notice a mistake?</span>
-                        <a data-toggle="modal" data-target="#aboutModal" data-text="Help_Improve" data-keyboard="true" style="cursor: pointer">Help us improve Apertium!</a>
+                        <a data-toggle="modal" data-target="#aboutModal" data-text="Help_Improve" data-keyboard="true" class="pointerCursor">Help us improve Apertium!</a>
                     </div>
                     <a id="version" class="text-muted hidden-sm hidden-xs" href="https://github.com/goavki/apertium-html-tools" target="_blank">
                         <small>
@@ -396,7 +396,7 @@
                 </div>
             </div>
 
-            <div class="pull-right well well-sm visible-xs helpMessage" style="margin-top: 10px;">
+            <div class="pull-right well well-sm visible-xs helpMessage" id="helpMessage">
                 <span data-text="Notice_Mistake">Notice a mistake?</span>
                 <a data-toggle="modal" data-target="#infoModal" data-text="Help_Improve" data-keyboard="true">Help us improve Apertium!</a>
             </div>
@@ -411,28 +411,28 @@
                     </div>
                     <div class="modal-body">
                         <div data-text="What_Is_Apertium"></div>
-                        <div data-text="Maintainer" style="padding-bottom: 2em;"></div>
+                        <div data-text="Maintainer" id="maintainer"></div>
 
                         <div class="row lead">
                             <div class="col-md-6">
                                 <div class="center-block">
-                                    <a href="https://developers.google.com/open-source/soc/" target="_blank" style="text-decoration: none">
-                                        <img alt="Google Summer of Code" data-src="https://summerofcode.withgoogle.com/static/img/summer-of-code-logo.svg" style="height: 2.5em;">
+                                    <a href="https://developers.google.com/open-source/soc/" target="_blank" class="nodecoration">
+                                        <img alt="Google Summer of Code" data-src="https://summerofcode.withgoogle.com/static/img/summer-of-code-logo.svg" id="gsocImg">
                                     </a>
-                                    <a href="https://developers.google.com/open-source/gci/" target="_blank" style="text-decoration: none">
-                                        <img alt="Google Code-In" data-src="https://developers.google.com/open-source/gci/images/logo-icon.png" style="height: 2.5em; padding-left: .5em;">
+                                    <a href="https://developers.google.com/open-source/gci/" target="_blank" class="nodecoration">
+                                        <img alt="Google Code-In" data-src="https://developers.google.com/open-source/gci/images/logo-icon.png" id="gciImg">
                                     </a>
                                 </div>
                             </div>
 
                             <div class="col-md-3 text-center">
                                 <a href="http://www.bytemark.co.uk/" target="_blank">
-                                    <img alt="Bytemark" data-src="./img/logo_bytemark.gif" style="width: 100%; margin-top: .5em">
+                                    <img alt="Bytemark" data-src="./img/logo_bytemark.gif"id="byteMarkImg">
                                 </a>
                             </div>
                             <div class="col-md-3 text-center">
                                 <a href="http://www.sourceforge.net" target="_blank">
-                                    <img alt="Sourceforge" data-src="./img/sourceforge.png" style="width: 100%; margin-top: .25em">
+                                    <img alt="Sourceforge" data-src="./img/sourceforge.png" id="sourceForgeImg">
                                 </a>
                             </div>
                         </div>
@@ -468,13 +468,13 @@
                             </div>
                         </div>
                         <div class="row">
-                            <div style="display: inline-block; margin: 0 .5em 0 .5em">
+                            <div class="display-inline halfEmMargin">
                                 <a href="http://creativecommons.org/licenses/by-sa/3.0/">
                                     <img alt="Creative Commons licence" data-src="./img/cc-by-sa-3.0-88x31.png">
                                 </a>
                             </div>
 
-                            <div style="display: inline-block; margin: 0 .5em 0 .5em">
+                            <div class="display-inline halfEmMargin">
                                 <a href="https://www.gnu.org/licenses/gpl.html">
                                     <img alt="GNU GPL License" data-src="./img/gplv3-88x31.png">
                                 </a>
@@ -547,9 +547,9 @@
                         </p>
                         <p data-text="Contact_Us"></p>
 
-                        <div class="center-block" style="margin-bottom: 1.5em;">
+                        <div class="center-block" id="apertiumImgContainer">
                             <a href="http://www.apertium.org/" target="_blank">
-                                <img alt="Apertium" data-src="./img/Apertium.png" class="center-block" style="height: 5em; max-width: 100%;">
+                                <img alt="Apertium" data-src="./img/Apertium.png" class="center-block" id="apertiumImg">
                             </a>
                         </div>
                     </div>
@@ -559,7 +559,7 @@
 
         <div id="noscript">
             <div class="lead text-warning well well-sm" data-text="Enable_JS_Warning"></div>
-            <noscript><p><img src="@include_piwik_url@/piwik.php?idsite=@include_piwik_siteid@" style="border: 0;" alt=""></p></noscript>
+            <noscript><p><img src="@include_piwik_url@/piwik.php?idsite=@include_piwik_siteid@" class="noborder" alt=""></p></noscript>
         </div>
         <button class="btn btn-default hidden-sm hidden-xs" id="backToTop"><i class="fa fa-arrow-up" aria-hidden="true"></i></button>
         <div id="installationNotice" class="hidden-xs hidden-sm alert alert-warning alert-dismissible">

--- a/index.html.in
+++ b/index.html.in
@@ -218,20 +218,20 @@
                               </div>
 
                               <div class="modal-backdrop" id="fileDropBackdrop">
-                                <div class="well well-lg" id="modalWell">
-                                    <h1 id="dropDocHeader" data-text="Drop_Document">Drop your document</h1>
+                                <div class="well well-lg">
+                                    <h1 data-text="Drop_Document">Drop your document</h1>
                                 </div>
                                 <div class="modal-backdrop" id="fileDropMask"></div>
                               </div>
 
-                              <div id="docTranslation" class="noDisplay">
+                              <div id="docTranslation" class="hide">
                                   <div class="col-sm-6">
                                       <div class="well well-lg">
                                           <input type="file" id="fileInput" accept="text/plain,text/html,text/rtf,application/rtf,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.openxmlformats-officedocument.presentationml.presentation,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.oasis.opendocument.text,application/x-latex,application/x-tex">
-                                          <div class="lead" id="fileName" class="noDisplay"></div>
+                                          <div class="lead" id="fileName" class="hide"></div>
                                           <div id="uploadContainer">
-                                              <span id="uploadError" class="text-danger lead noDisplay"></span>
-                                              <div class="progress progress-striped active noDisplay" id="uploadProgress">
+                                              <span id="uploadError" class="text-danger lead hide"></span>
+                                              <div class="progress progress-striped active hide" id="uploadProgress">
                                                   <div id="fileUploadProgress" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
                                               </div>
                                           </div>
@@ -242,16 +242,16 @@
                                       </div>
                                   </div>
                                   <div class="col-sm-6">
-                                      <div id="fileLoading" class="text-center noDisplay">
+                                      <div id="fileLoading" class="text-center hide">
                                           <i class="fa fa-spinner fa-spin fa-4x"></i>
                                       </div>
                                       <h1>
-                                          <a id="fileDownload" href="#" class="text-center lead noDisplay">
+                                          <a id="fileDownload" href="#" class="text-center lead hide">
                                               <i class="fa fa-download"></i>
                                               <span id="fileDownloadText"></span>
                                           </a>
                                       </h1>
-                                      <p class="noDisplay" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser might not handle downloads correctly. Either right-click and "Save As" that file-name or open this page in Firefox.</p>
+                                      <p class="hide" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser might not handle downloads correctly. Either right-click and "Save As" that file-name or open this page in Firefox.</p>
                                   </div>
                               </div>
                               <div id="translateWebpage">
@@ -468,13 +468,13 @@
                             </div>
                         </div>
                         <div class="row">
-                            <div class="display-inline halfEmMargin">
+                            <div class="display-inline licenseCol">
                                 <a href="http://creativecommons.org/licenses/by-sa/3.0/">
                                     <img alt="Creative Commons licence" data-src="./img/cc-by-sa-3.0-88x31.png">
                                 </a>
                             </div>
 
-                            <div class="display-inline halfEmMargin">
+                            <div class="display-inline licenseCol">
                                 <a href="https://www.gnu.org/licenses/gpl.html">
                                     <img alt="GNU GPL License" data-src="./img/gplv3-88x31.png">
                                 </a>

--- a/index.html.in
+++ b/index.html.in
@@ -74,7 +74,7 @@
 
         <div id="wrap">
           <nav class="navbar navbar-default" role="navigation">
-              <div class="container posRelative">
+              <div class="container position-relative">
                   <div class="navbar-header">
                       <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                           <span class="sr-only">Toggle navigation</span>
@@ -89,7 +89,7 @@
                       </div>
                       <p data-text="tagline" class="tagline"></p>
                   </div>
-                  <div id="localeSelectDiv" class="pull-right hidden-xs">
+                  <div id="localeSelectContainer" class="pull-right hidden-xs">
                       <!-- <i class="icon-globe localeGlobe pull-right"></i> -->
                       <i class="fa fa-globe fa-2x fa-inverse pull-right localeGlobe" id="localeGlobeIcon"></i>
                       <select class="localeSelect pull-right"><option> </option></select>
@@ -125,7 +125,7 @@
                           </div>
                           <div class="form-group hidden-xs">
                               <div class="col-sm-6">
-                                  <button type="button" class="btn btn-sm btn-default pull-left" id="cancelTranslateWebpage">
+                                  <button type="button" class="btn btn-sm btn-default pull-left hide">
                                       <i class="fa fa-arrow-left"></i> <span data-text="Cancel">Cancel</span>
                                   </button>
                                   <div class="btn-group col-sm-11" id="srcLangSelectors">
@@ -368,7 +368,7 @@
               </div>
               <div class="visible-xs">
                   <select class="localeSelect pull-left"><option> </option></select>
-                  <i class="fa fa-globe fa-2x pull-left localeGlobe" id="localeGlobeIconXs"></i>
+                  <i class="fa fa-globe fa-2x pull-left localeGlobe" id="localeGlobeIconXS"></i>
                   <!-- <i class="fa fa-globe localeGlobe pull-left"></i> -->
               </div>
           </div>
@@ -386,7 +386,7 @@
                     </ul>
                     <div class="pull-right well well-sm helpMessage">
                         <span data-text="Notice_Mistake">Notice a mistake?</span>
-                        <a data-toggle="modal" data-target="#aboutModal" data-text="Help_Improve" data-keyboard="true" class="pointerCursor">Help us improve Apertium!</a>
+                        <a data-toggle="modal" data-target="#aboutModal" data-text="Help_Improve" data-keyboard="true" class="helpMessage">Help us improve Apertium!</a>
                     </div>
                     <a id="version" class="text-muted hidden-sm hidden-xs" href="https://github.com/goavki/apertium-html-tools" target="_blank">
                         <small>
@@ -396,7 +396,7 @@
                 </div>
             </div>
 
-            <div class="pull-right well well-sm visible-xs helpMessage" id="helpMessage">
+            <div class="pull-right well well-sm visible-xs helpMessage" id="helpMessageXS">
                 <span data-text="Notice_Mistake">Notice a mistake?</span>
                 <a data-toggle="modal" data-target="#infoModal" data-text="Help_Improve" data-keyboard="true">Help us improve Apertium!</a>
             </div>
@@ -416,10 +416,10 @@
                         <div class="row lead">
                             <div class="col-md-6">
                                 <div class="center-block">
-                                    <a href="https://developers.google.com/open-source/soc/" target="_blank" class="nodecoration">
+                                    <a href="https://developers.google.com/open-source/soc/" target="_blank" class="no-decoration">
                                         <img alt="Google Summer of Code" data-src="https://summerofcode.withgoogle.com/static/img/summer-of-code-logo.svg" id="gsocImg">
                                     </a>
-                                    <a href="https://developers.google.com/open-source/gci/" target="_blank" class="nodecoration">
+                                    <a href="https://developers.google.com/open-source/gci/" target="_blank" class="no-decoration">
                                         <img alt="Google Code-In" data-src="https://developers.google.com/open-source/gci/images/logo-icon.png" id="gciImg">
                                     </a>
                                 </div>
@@ -549,7 +549,7 @@
 
                         <div class="center-block" id="apertiumImgContainer">
                             <a href="http://www.apertium.org/" target="_blank">
-                                <img alt="Apertium" data-src="./img/Apertium.png" class="center-block" id="apertiumImg">
+                                <img alt="Apertium" data-src="./img/Apertium.png" class="center-block">
                             </a>
                         </div>
                     </div>
@@ -559,7 +559,7 @@
 
         <div id="noscript">
             <div class="lead text-warning well well-sm" data-text="Enable_JS_Warning"></div>
-            <noscript><p><img src="@include_piwik_url@/piwik.php?idsite=@include_piwik_siteid@" class="noborder" alt=""></p></noscript>
+            <noscript><p><img src="@include_piwik_url@/piwik.php?idsite=@include_piwik_siteid@" class="border-0" alt=""></p></noscript>
         </div>
         <button class="btn btn-default hidden-sm hidden-xs" id="backToTop"><i class="fa fa-arrow-up" aria-hidden="true"></i></button>
         <div id="installationNotice" class="hidden-xs hidden-sm alert alert-warning alert-dismissible">


### PR DESCRIPTION
Eliminates inline styling from index.html.in
Adds HTML Lint rule "inline-style-disabled": true
Moves all inline styling code to assets/css/style.css

Related to Issue https://github.com/goavki/apertium-html-tools/issues/114

Done according to: https://codein.withgoogle.com/dashboard/task-instances/5437388455149568/