### PR TITLE
File download in IE10+ fixing #97

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -743,11 +743,20 @@ function translateDoc() {
                         downloadBrowserWarn();
                         $('div#fileUploadProgress').parent().fadeOut('fast');
                         $('div#fileLoading').fadeOut('fast', function () {
-                            var URL = window.URL || window.webkitURL;
-                            $('a#fileDownload')
-                                .attr('href', URL.createObjectURL(xhr.response))
-                                .attr('download', fileName)
-                                .fadeIn('fast');
+                            if(typeof window.navigator.msSaveBlob !== 'undefined') {
+                                $('a#fileDownload')
+                                    .click(function () {
+                                        window.navigator.msSaveBlob(xhr.response, fileName);
+                                    })
+                                    .fadeIn('fast');
+                            }
+                            else {
+                                var URL = window.URL || window.webkitURL;
+                                $('a#fileDownload')
+                                    .attr('href', URL.createObjectURL(xhr.response))
+                                    .attr('download', fileName)
+                                    .fadeIn('fast');
+                            }
                             $('span#fileDownloadText').text(getDynamicLocalization('Download_File').replace('{{fileName}}', fileName));
                             $('button#translate').prop('disabled', false);
                             $('input#fileInput').prop('disabled', false);


### PR DESCRIPTION
I added a non-breaking workaround for issue #97 in IE10 and 11.  
  
I tested both of them in virtual machine at Sauce Labs, logs for [IE10](https://saucelabs.com/beta/tests/5b3dda1b469941da93b32821ce818a62/metadata) and [IE11](https://saucelabs.com/beta/tests/f3bd41c0197b44cc9a02aabd83d5e30e/metadata).  
Also checked Chrome 62 locally and can confirm it works as before the change.

This is a part of [Google Code-In task](https://codein.withgoogle.com/dashboard/task-instances/5358971881783296/)

(Screenshot from IE)
![0003screenshot](https://user-images.githubusercontent.com/19410489/33499989-7b3f781c-d6d7-11e7-845b-663b2269801f.png)
