### PR TITLE
Add file download workaround for Safari (progress #97)

### DIFF
--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -740,7 +740,6 @@ function translateDoc() {
                         });
                     }
                     else if(this.readyState === XHR_DONE && xhr.status === HTTP_OK_CODE) {
-                        downloadBrowserWarn();
                         $('div#fileUploadProgress').parent().fadeOut('fast');
                         $('div#fileLoading').fadeOut('fast', function () {
                             if(typeof window.navigator.msSaveBlob !== 'undefined') {
@@ -760,7 +759,6 @@ function translateDoc() {
                                         .click(function () {
                                             window.location.href = reader.result.replace(/^data:[^;]*;/, 'data:attachment/file;');
                                         });
-                                    $('#fileDownloadBrowserWarning').show();
                                 };
                                 reader.readAsDataURL(xhr.response);
                             }
@@ -956,16 +954,6 @@ function showTranslateWebpageInterface(url, ignoreIfEmpty) {
         window.location.hash = 'webpageTranslation';
         translateWebpage(ignoreIfEmpty);
     });
-}
-
-function downloadBrowserWarn() {
-    if(typeof $bu_getBrowser == 'function') { // eslint-disable-line camelcase
-        var detected = $bu_getBrowser();
-        // Show the warning for (what bu calls) "niche" browsers and Safari, but not Chromium:
-        if(detected.n.match(/^[xs]/) && !(navigator.userAgent.match(/Chromium/))) {
-            $('#fileDownloadBrowserWarning').show();
-        }
-    }
 }
 
 function detectLanguage() {

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -743,11 +743,20 @@ function translateDoc() {
                         downloadBrowserWarn();
                         $('div#fileUploadProgress').parent().fadeOut('fast');
                         $('div#fileLoading').fadeOut('fast', function () {
-                            var URL = window.URL || window.webkitURL;
-                            $('a#fileDownload')
-                                .attr('href', URL.createObjectURL(xhr.response))
-                                .attr('download', fileName)
-                                .fadeIn('fast');
+                            if(typeof window.navigator.msSaveBlob !== 'undefined') {
+                                $('a#fileDownload')
+                                    .click(function () {
+                                        window.navigator.msSaveBlob(xhr.response, fileName);
+                                    })
+                                    .fadeIn('fast');
+                            }
+                            else {
+                                var URL = window.URL || window.webkitURL;
+                                $('a#fileDownload')
+                                    .attr('href', URL.createObjectURL(xhr.response))
+                                    .attr('download', fileName)
+                                    .fadeIn('fast');
+                            }
                             $('span#fileDownloadText').text(getDynamicLocalization('Download_File').replace('{{fileName}}', fileName));
                             $('button#translate').prop('disabled', false);
                             $('input#fileInput').prop('disabled', false);

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -25,7 +25,6 @@ var PUNCTUATION_KEY_CODES = [46, 33, 58, 63, 47, 45, 190, 171, 49]; // eslint-di
     getDynamicLocalization, locale, ajaxSend, ajaxComplete, localizeInterface, filterLangList, cache, readCache, iso639Codes,
     callApy, apyRequestTimeout, isURL */
 /* global SPACE_KEY_CODE, ENTER_KEY_CODE, HTTP_OK_CODE, XHR_LOADING, XHR_DONE, HTTP_OK_CODE, HTTP_BAD_REQUEST_CODE */
-/* global $bu_getBrowser */
 
 if(modeEnabled('translation')) {
     $(document).ready(function () {

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -749,9 +749,8 @@ function translateDoc() {
                                         window.navigator.msSaveBlob(xhr.response, fileName);
                                     });
                             }
-                            else if(/.*(?!chrome|android).*(version\/[^10,11]|Mobile).*safari/i.test(window.navigator.userAgent) &&
+                            else if(/.*(?!chrome|android).*(version\/\d\.|Mobile).*safari/i.test(window.navigator.userAgent) &&
                                 !/chrome/i.test(window.navigator.userAgent)) {
-                                // When a new version of Safari comes out ^^ need to update
                                 // Safari <9 + Mobile file download workaround
                                 var reader = new FileReader();
                                 reader.onload = function () {

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -744,12 +744,14 @@ function translateDoc() {
                         $('div#fileUploadProgress').parent().fadeOut('fast');
                         $('div#fileLoading').fadeOut('fast', function () {
                             if(typeof window.navigator.msSaveBlob !== 'undefined') {
+                                // IE file download workaround
                                 $('a#fileDownload')
                                     .click(function () {
                                         window.navigator.msSaveBlob(xhr.response, fileName);
                                     });
                             }
                             else if(/^((?!chrome|android).)*safari/i.test(window.navigator.userAgent)) {
+                                // Safari file download workaround
                                 var reader = new FileReader();
                                 reader.onload = function () {
                                     $('a#fileDownload')
@@ -761,6 +763,7 @@ function translateDoc() {
                                 reader.readAsDataURL(xhr.response);
                             }
                             else {
+                                // File download for modern browsers
                                 var URL = window.URL || window.webkitURL;
                                 $('a#fileDownload')
                                     .attr('href', URL.createObjectURL(xhr.response))

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -762,14 +762,12 @@ function translateDoc() {
                                 };
                                 reader.readAsDataURL(xhr.response);
                             }
-                            else {
-                                // File download for modern browsers
-                                var URL = window.URL || window.webkitURL;
-                                $('a#fileDownload')
-                                    .attr('href', URL.createObjectURL(xhr.response))
-                                    .attr('download', fileName);
-                            }
-                            $('a#fileDownload').fadeIn('fast');
+                            // File download for modern browsers and right-click to save
+                            var URL = window.URL || window.webkitURL;
+                            $('a#fileDownload')
+                                .attr('href', URL.createObjectURL(xhr.response))
+                                .attr('download', fileName)
+                                .fadeIn('fast');
                             $('span#fileDownloadText').text(getDynamicLocalization('Download_File').replace('{{fileName}}', fileName));
                             $('button#translate').prop('disabled', false);
                             $('input#fileInput').prop('disabled', false);

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -747,8 +747,7 @@ function translateDoc() {
                                 $('a#fileDownload')
                                     .click(function () {
                                         window.navigator.msSaveBlob(xhr.response, fileName);
-                                    })
-                                    .fadeIn('fast');
+                                    });
                             }
                             else if(/^((?!chrome|android).)*safari/i.test(window.navigator.userAgent)) {
                                 var reader = new FileReader();
@@ -756,8 +755,7 @@ function translateDoc() {
                                     $('a#fileDownload')
                                         .click(function () {
                                             window.location.href = reader.result.replace(/^data:[^;]*;/, 'data:attachment/file;');
-                                        })
-                                        .fadeIn('fast');
+                                        });
                                     $('#fileDownloadBrowserWarning').show();
                                 };
                                 reader.readAsDataURL(xhr.response);
@@ -766,9 +764,9 @@ function translateDoc() {
                                 var URL = window.URL || window.webkitURL;
                                 $('a#fileDownload')
                                     .attr('href', URL.createObjectURL(xhr.response))
-                                    .attr('download', fileName)
-                                    .fadeIn('fast');
+                                    .attr('download', fileName);
                             }
+                            $('a#fileDownload').fadeIn('fast');
                             $('span#fileDownloadText').text(getDynamicLocalization('Download_File').replace('{{fileName}}', fileName));
                             $('button#translate').prop('disabled', false);
                             $('input#fileInput').prop('disabled', false);

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -750,8 +750,10 @@ function translateDoc() {
                                         window.navigator.msSaveBlob(xhr.response, fileName);
                                     });
                             }
-                            else if(/^((?!chrome|android).)*safari/i.test(window.navigator.userAgent)) {
-                                // Safari file download workaround
+                            else if(/.*(?!chrome|android).*(version\/[^10,11]|Mobile).*safari/i.test(window.navigator.userAgent) &&
+                                !/chrome/i.test(window.navigator.userAgent)) {
+                                // When a new version of Safari comes out ^^ need to update
+                                // Safari <9 + Mobile file download workaround
                                 var reader = new FileReader();
                                 reader.onload = function () {
                                     $('a#fileDownload')

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -750,7 +750,10 @@ function translateDoc() {
                             }
                             else if(/.*(?!chrome|android).*(version\/\d\.|Mobile).*safari/i.test(window.navigator.userAgent) &&
                                 !/chrome/i.test(window.navigator.userAgent)) {
-                                // Safari <9 + Mobile file download workaround
+                                /* Safari <9 + Mobile file download workaround
+                                 * Tests User Agent against a regexp to detect if the user is on older or mobile version of
+                                 * Safari and then runs another test to eliminate Chrome, which also include Safari in UA.
+                                 */
                                 var reader = new FileReader();
                                 reader.onload = function () {
                                     $('a#fileDownload')

--- a/assets/js/translator.js
+++ b/assets/js/translator.js
@@ -750,6 +750,18 @@ function translateDoc() {
                                     })
                                     .fadeIn('fast');
                             }
+                            else if(/^((?!chrome|android).)*safari/i.test(window.navigator.userAgent)) {
+                                var reader = new FileReader();
+                                reader.onload = function () {
+                                    $('a#fileDownload')
+                                        .click(function () {
+                                            window.location.href = reader.result.replace(/^data:[^;]*;/, 'data:attachment/file;');
+                                        })
+                                        .fadeIn('fast');
+                                    $('#fileDownloadBrowserWarning').show();
+                                };
+                                reader.readAsDataURL(xhr.response);
+                            }
                             else {
                                 var URL = window.URL || window.webkitURL;
                                 $('a#fileDownload')

--- a/assets/strings/arg.json
+++ b/assets/strings/arg.json
@@ -9,7 +9,6 @@
         ],
         "completion": " 88%  93.21%",
         "missing": [
-            "Download_Browser_Warning",
             "Install_Apertium",
             "Install_Apertium_Para",
             "Mark_Unknown_Words",

--- a/assets/strings/ava.json
+++ b/assets/strings/ava.json
@@ -19,7 +19,6 @@
             "Documentation",
             "Documentation_Para",
             "Download",
-            "Download_Browser_Warning",
             "Download_File",
             "Downloads_Para",
             "Drop_Document",

--- a/assets/strings/cat.json
+++ b/assets/strings/cat.json
@@ -11,7 +11,6 @@
         ],
         "completion": " 84%  89.06%",
         "missing": [
-            "Download_Browser_Warning",
             "Drop_Document",
             "Install_Apertium",
             "Install_Apertium_Para",

--- a/assets/strings/deu.json
+++ b/assets/strings/deu.json
@@ -33,7 +33,6 @@
     "Format_Not_Supported": "Format wird nicht unterstützt!",
     "Translate_Webpage": "Eine Webseite übersetzen",
     "Supported_Formats": "Unterstützte Formate: .txt, .rtf, .odp, .ods, .odt (LibreOffice/OpenOffice), .xlsx, .pptx, .docx (Microsoft Office 2003 und neuer). <br/><i>.doc-Dateien von Word 97 und PDFs werden nicht unterstützt.</i>",
-    "Download_Browser_Warning": "Ihr Browser lädt Dateien möglicherweise nicht korrekt herunter. Speichern Sie den Link entweder per Rechtsklick unter dem richtigen Dateinamen oder öffnen Sie diese Seite in <a href=\"https://www.mozilla.org/firefox/\">Firefox</a>.",
     "Download_File": "{{fileName}} herunterladen",
     "Morphological_Analysis": "Morphologische Analyse",
     "Morphological_Analysis_Help": "Wählen Sie eine Sprache und analysieren Sie Ihren Text mit Apertiums morphologischen Analysierern.",

--- a/assets/strings/eng.json
+++ b/assets/strings/eng.json
@@ -30,7 +30,7 @@
     "Format_Not_Supported": "Format not supported",
     "Translate_Webpage": "Translate a webpage",
     "Supported_Formats": "Supported formats: .txt, .rtf, .odp, .ods, .odt (LibreOffice/OpenOffice), .xlsx, .pptx, .docx (Microsoft Office 2003 and newer). <br/><i>Word 97 .doc files and pdf's are not supported.</i>",
-    "Download_Browser_Warning": "Your browser does not handle downloads correctly so downloaded file will save as \"Unknown\", you might want to rename it. Alternatively you can open this page in a browser that handles downloads properly, such as <a href=\"https://www.mozilla.org/firefox/\">Firefox</a>.",
+    "Download_Browser_Warning": "Your browser might not handle downloads correctly. Either right-click and save the link with the correct filename or open this page in <a href=\"https://www.mozilla.org/firefox/\">Firefox</a>.",
     "Download_File": "Download {{fileName}}",
     "Morphological_Analysis": "Morphological analysis",
     "Morphological_Analysis_Help": "Choose a language and analyse your text using Apertium's morphological analysers.",

--- a/assets/strings/eng.json
+++ b/assets/strings/eng.json
@@ -30,7 +30,7 @@
     "Format_Not_Supported": "Format not supported",
     "Translate_Webpage": "Translate a webpage",
     "Supported_Formats": "Supported formats: .txt, .rtf, .odp, .ods, .odt (LibreOffice/OpenOffice), .xlsx, .pptx, .docx (Microsoft Office 2003 and newer). <br/><i>Word 97 .doc files and pdf's are not supported.</i>",
-    "Download_Browser_Warning": "Your browser might not handle downloads correctly. Either right-click and save the link with the correct filename or open this page in <a href=\"https://www.mozilla.org/firefox/\">Firefox</a>.",
+    "Download_Browser_Warning": "Your browser does not handle downloads correctly so downloaded file will save as \"Unknown\", you might want to rename it. Alternatively you can open this page in a browser that handles downloads properly, such as <a href=\"https://www.mozilla.org/firefox/\">Firefox</a>.",
     "Download_File": "Download {{fileName}}",
     "Morphological_Analysis": "Morphological analysis",
     "Morphological_Analysis_Help": "Choose a language and analyse your text using Apertium's morphological analysers.",

--- a/assets/strings/eng.json
+++ b/assets/strings/eng.json
@@ -30,8 +30,6 @@
     "Format_Not_Supported": "Format not supported",
     "Translate_Webpage": "Translate a webpage",
     "Supported_Formats": "Supported formats: .txt, .rtf, .odp, .ods, .odt (LibreOffice/OpenOffice), .xlsx, .pptx, .docx (Microsoft Office 2003 and newer). <br/><i>Word 97 .doc files and pdf's are not supported.</i>",
-    "Download_Browser_Warning": "Your browser might not handle downloads correctly. Either right-click and save the link with the correct filename or open this page in <a href=\"https://www.mozilla.org/firefox/\">Firefox</a>.",
-    "Download_File": "Download {{fileName}}",
     "Morphological_Analysis": "Morphological analysis",
     "Morphological_Analysis_Help": "Choose a language and analyse your text using Apertium's morphological analysers.",
     "Analyze": "Analyse",

--- a/assets/strings/eus.json
+++ b/assets/strings/eus.json
@@ -16,7 +16,6 @@
             "Documentation",
             "Documentation_Para",
             "Download",
-            "Download_Browser_Warning",
             "Download_File",
             "Downloads_Para",
             "Drop_Document",

--- a/assets/strings/fin.json
+++ b/assets/strings/fin.json
@@ -11,7 +11,6 @@
         ],
         "completion": " 84%  75.50%",
         "missing": [
-            "Download_Browser_Warning",
             "Drop_Document",
             "Install_Apertium",
             "Install_Apertium_Para",

--- a/assets/strings/fra.json
+++ b/assets/strings/fra.json
@@ -12,7 +12,6 @@
         "completion": " 73%  87.19%",
         "missing": [
             "Cancel",
-            "Download_Browser_Warning",
             "Download_File",
             "Drop_Document",
             "File_Too_Large",

--- a/assets/strings/heb.json
+++ b/assets/strings/heb.json
@@ -11,7 +11,6 @@
         "completion": " 73%  68.24%",
         "missing": [
             "Cancel",
-            "Download_Browser_Warning",
             "Download_File",
             "Drop_Document",
             "File_Too_Large",

--- a/assets/strings/kaa.json
+++ b/assets/strings/kaa.json
@@ -9,7 +9,6 @@
         ],
         "completion": " 84%  87.56%",
         "missing": [
-            "Download_Browser_Warning",
             "Drop_Document",
             "Install_Apertium",
             "Install_Apertium_Para",

--- a/assets/strings/kaz.json
+++ b/assets/strings/kaz.json
@@ -12,7 +12,6 @@
         "completion": " 73%  77.37%",
         "missing": [
             "Cancel",
-            "Download_Browser_Warning",
             "Download_File",
             "Drop_Document",
             "File_Too_Large",

--- a/assets/strings/kir.json
+++ b/assets/strings/kir.json
@@ -13,7 +13,6 @@
         "missing": [
             "Contact_Para",
             "Documentation_Para",
-            "Download_Browser_Warning",
             "Downloads_Para",
             "Drop_Document",
             "Format_Not_Supported",

--- a/assets/strings/nno.json
+++ b/assets/strings/nno.json
@@ -10,7 +10,6 @@
         ],
         "completion": " 86%  81.41%",
         "missing": [
-            "Download_Browser_Warning",
             "Install_Apertium",
             "Install_Apertium_Para",
             "Mark_Unknown_Words",

--- a/assets/strings/nob.json
+++ b/assets/strings/nob.json
@@ -33,7 +33,6 @@
     "Cancel": "Avbryt",
     "Format_Not_Supported": "Det formatet er ikke støttet!",
     "Supported_Formats": "Støttede format: .txt, .rtf, .odp, .ods, .odt (LibreOffice/OpenOffice), .xlsx, .pptx, .docx (Microsoft Office 2003 og nyere). <br/><i>Word 97 .doc-filer og pdf-er støttes ikke.</i>",
-    "Download_Browser_Warning": "Nettleseren din støtter kanskje ikke nedlastinger korrekt. Enten høyreklikk og lagre lenken med korrekt filnavn, eller åpne denne siden i <a href=\"https://www.mozilla.org/firefox/\">Firefox</a>.",
     "Download_File": "Last ned {{fileName}}",
     "Morphological_Analysis": "Morfologisk analyse",
     "Morphological_Analysis_Help": "Velg et språk og analyser teksten din med de morfologiske analysatorene til Apertium.",

--- a/assets/strings/oci.json
+++ b/assets/strings/oci.json
@@ -11,7 +11,6 @@
         "completion": " 73%  84.29%",
         "missing": [
             "Cancel",
-            "Download_Browser_Warning",
             "Download_File",
             "Drop_Document",
             "File_Too_Large",

--- a/assets/strings/por.json
+++ b/assets/strings/por.json
@@ -19,7 +19,6 @@
             "Documentation",
             "Documentation_Para",
             "Download",
-            "Download_Browser_Warning",
             "Download_File",
             "Downloads_Para",
             "Drop_Document",

--- a/assets/strings/ron.json
+++ b/assets/strings/ron.json
@@ -21,7 +21,6 @@
             "Documentation",
             "Documentation_Para",
             "Download",
-            "Download_Browser_Warning",
             "Download_File",
             "Downloads_Para",
             "Drop_Document",

--- a/assets/strings/rus.json
+++ b/assets/strings/rus.json
@@ -13,7 +13,6 @@
         ],
         "completion": " 88%  82.38%",
         "missing": [
-            "Download_Browser_Warning",
             "Install_Apertium",
             "Install_Apertium_Para",
             "Mark_Unknown_Words",

--- a/assets/strings/sme.json
+++ b/assets/strings/sme.json
@@ -15,7 +15,6 @@
             "Apertium_Downloads",
             "Contact_Para",
             "Documentation_Para",
-            "Download_Browser_Warning",
             "Download_File",
             "Downloads_Para",
             "Drop_Document",

--- a/assets/strings/spa.json
+++ b/assets/strings/spa.json
@@ -14,7 +14,6 @@
         "missing": [
             "Contact_Para",
             "Documentation_Para",
-            "Download_Browser_Warning",
             "Downloads_Para",
             "Drop_Document",
             "Install_Apertium",

--- a/assets/strings/srd.json
+++ b/assets/strings/srd.json
@@ -7,7 +7,6 @@
         ],
         "completion": " 89%  91.53%",
         "missing": [
-            "Download_Browser_Warning",
             "Install_Apertium",
             "Install_Apertium_Para",
             "Multi_Step_Translation",

--- a/assets/strings/swe.json
+++ b/assets/strings/swe.json
@@ -9,7 +9,6 @@
         ],
         "completion": " 88%  86.68%",
         "missing": [
-            "Download_Browser_Warning",
             "Install_Apertium",
             "Install_Apertium_Para",
             "Mark_Unknown_Words",

--- a/assets/strings/tat.json
+++ b/assets/strings/tat.json
@@ -15,7 +15,6 @@
             "Cancel",
             "Contact_Para",
             "Documentation_Para",
-            "Download_Browser_Warning",
             "Download_File",
             "Downloads_Para",
             "Drop_Document",

--- a/assets/strings/tha.json
+++ b/assets/strings/tha.json
@@ -7,7 +7,6 @@
         ],
         "completion": " 84%  75.76%",
         "missing": [
-            "Download_Browser_Warning",
             "Drop_Document",
             "Install_Apertium",
             "Install_Apertium_Para",

--- a/assets/strings/tur.json
+++ b/assets/strings/tur.json
@@ -10,7 +10,6 @@
         ],
         "completion": " 88%  84.91%",
         "missing": [
-            "Download_Browser_Warning",
             "Install_Apertium",
             "Install_Apertium_Para",
             "Mark_Unknown_Words",

--- a/assets/strings/uig.json
+++ b/assets/strings/uig.json
@@ -11,7 +11,6 @@
         "completion": " 73%  77.95%",
         "missing": [
             "Cancel",
-            "Download_Browser_Warning",
             "Download_File",
             "Drop_Document",
             "File_Too_Large",

--- a/assets/strings/uzb.json
+++ b/assets/strings/uzb.json
@@ -10,7 +10,6 @@
         ],
         "completion": " 88%  92.18%",
         "missing": [
-            "Download_Browser_Warning",
             "Install_Apertium",
             "Install_Apertium_Para",
             "Mark_Unknown_Words",

--- a/assets/strings/zho.json
+++ b/assets/strings/zho.json
@@ -18,7 +18,6 @@
             "Cancel",
             "Contact_Para",
             "Documentation_Para",
-            "Download_Browser_Warning",
             "Download_File",
             "Downloads_Para",
             "Drop_Document",

--- a/index.html.in
+++ b/index.html.in
@@ -251,7 +251,7 @@
                                               <span id="fileDownloadText"></span>
                                           </a>
                                       </h1>
-                                      <p style="display:none" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser does not handle downloads correctly so downloaded file will save as "Unknown", you might want to rename it. Alternatively you can open this page in a browser that handles downloads properly, such as Firefox.</p>
+                                      <p style="display:none" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser might not handle downloads correctly. Either right-click and "Save As" that file-name or open this page in Firefox.</p>
                                   </div>
                               </div>
                               <div id="translateWebpage">

--- a/index.html.in
+++ b/index.html.in
@@ -251,7 +251,6 @@
                                               <span id="fileDownloadText"></span>
                                           </a>
                                       </h1>
-                                      <p style="display:none" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser might not handle downloads correctly. Either right-click and "Save As" that file-name or open this page in Firefox.</p>
                                   </div>
                               </div>
                               <div id="translateWebpage">

--- a/index.html.in
+++ b/index.html.in
@@ -251,7 +251,7 @@
                                               <span id="fileDownloadText"></span>
                                           </a>
                                       </h1>
-                                      <p style="display:none" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser might not handle downloads correctly. Either right-click and "Save As" that file-name or open this page in Firefox.</p>
+                                      <p style="display:none" id="fileDownloadBrowserWarning" data-text="Download_Browser_Warning">Your browser does not handle downloads correctly so downloaded file will save as "Unknown", you might want to rename it. Alternatively you can open this page in a browser that handles downloads properly, such as Firefox.</p>
                                   </div>
                               </div>
                               <div id="translateWebpage">


### PR DESCRIPTION
I added another workaround to file downloading, this time for Safari. I tested it on Chrome 62 and Safari 9 (on cloud machine) but as it's not as clean workaround as #215 I'd recommend that someone with access to more local browsers would test this. The file now downloads and is correctly recognised but downloads without extension type and with name 'Unknown' but I can't find any better way to do that.
I also updated the English string to be more specific in current situation but I didn't want to break anything so I left other languages untouched.

[Logs for Safari 9](https://saucelabs.com/beta/tests/7c83ff01d5b348cb82612ae835ae0834)
![0003screenshot](https://user-images.githubusercontent.com/19410489/33527293-71b5227e-d84e-11e7-8377-5c8466aaaa10.png)

This is a part of [GCI task](https://codein.withgoogle.com/dashboard/task-instances/5358971881783296/)